### PR TITLE
poprawka alltube

### DIFF
--- a/plugin.video.mrknow/lib/mrknow_Pageparser.py
+++ b/plugin.video.mrknow/lib/mrknow_Pageparser.py
@@ -272,7 +272,7 @@ class mrknow_Pageparser:
         query_data = {'url': url, 'use_host': False, 'use_cookie': False, 'use_post': False, 'return_data': True}
         link = self.cm.getURLRequestData(query_data)
         match1 = re.compile(
-            '<td><img src="(.*?)" alt="(.*?)"> (.*?)</td>\n              <td class="text-center">(.*?)</td>\n              <td class="text-center"><a class="watch" data-urlhost="(.*?)" data-iframe="(.*?)" data-version="(.*?)" data-short="(.*?)" data-size="(.*?)" (.*?)>(.*?)</a>\n                            </td>').findall(
+            '<td><img src="(.*?)" alt="(.*?)"> (.*?)</td>\n              <td class="text-center">(.*?)</td>\n              <td class="text-center"><a class="watch" data-iframe="(.*?)" data-version="(.*?)" data-short="(.*?)" data-size="(.*?)" (.*?)>(.*?)</a>\n                            </td>').findall(
             link)
         # print("Match1",match1)
         tab = []
@@ -280,8 +280,8 @@ class mrknow_Pageparser:
         if match1:
             for i in range(len(match1)):
                 # print("Link", match1[i])
-                tab.append(match1[i][6] + ' - ' + self.getHostName(match1[i][4]))
-                tab2.append(match1[i][4])
+                tab.append(match1[i][5] + ' - ' + self.getHostName(match1[i][4].decode('base64')))
+                tab2.append(match1[i][4].decode('base64'))
             d = xbmcgui.Dialog()
             video_menu = d.select("Wybór strony video", tab)
             if video_menu != "":


### PR DESCRIPTION
Alltube zmienił sposób linkowania - od teraz w atrybucie 'data-iframe' znajduje się URL do filmu zakodowany w Base64.

Poprawiłem regexpa wyciągającego linki + dodałem dekodowanie z base64 - u mnie w domu działa (żonka spokojnie sobie ogląda swoje seriale) :)